### PR TITLE
Bug correction: display username of the comment author

### DIFF
--- a/lib/client/templates.html
+++ b/lib/client/templates.html
@@ -1,11 +1,11 @@
 <template name="commentForm">
     {{#autoForm collection="Comments" id="commentForm" type="insert" commentDocId=_id}}
-      {{> afQuickField name='content' id='content' rows=2}}
-    <button type="submit" doc="{{_id}}" class="btn btn-primary btn-sm">Comment</button>
-    {{#if cancelButton}}
-    <a class="btn-cancel-comment">Cancel</a>
-    {{/if}}
-  {{/autoForm}}
+        {{> afQuickField name='content' id='content' rows=2}}
+        <button type="submit" doc="{{_id}}" class="btn btn-primary btn-sm">Comment</button>
+        {{#if cancelButton}}
+            <a class="btn-cancel-comment">Cancel</a>
+        {{/if}}
+    {{/autoForm}}
 </template>
 
 <template name="commentFormToggle">
@@ -22,7 +22,7 @@
         {{#if CommentsByDoc _id}}
             <hr/>
             {{#each CommentsByDoc _id}}
-                    {{> comment}}
+                {{> comment}}
             {{/each}}
         {{else}}
             {{> noComments}}
@@ -37,7 +37,7 @@
 		</a>
 		<div class="media-body">
             <p>{{content}}</p>
-			<small class="media-heading">{{niceName}}</small>
+			<small class="media-heading">{{niceName owner}}</small>
 		</div>
 	</div>
 </template>

--- a/lib/client/templates.html
+++ b/lib/client/templates.html
@@ -31,21 +31,21 @@
 </template>
 
 <template name="comment">
-	<div class="media comment">
-		<a class="pull-left" href="#">
-			{{> profileThumb _id=owner}}
-		</a>
-		<div class="media-body">
+    <div class="media comment">
+        <a class="pull-left" href="#">
+            {{> profileThumb _id=owner}}
+        </a>
+        <div class="media-body">
             <p>{{content}}</p>
-			<small class="media-heading">{{niceName owner}}</small>
-		</div>
-	</div>
+            <small class="media-heading">{{niceName owner}}</small>
+        </div>
+    </div>
 </template>
 
 <template name="hasComments">
     {{#each comments}}
         <div style="padding:20px">
-	        <div class="tip left">
+            <div class="tip left">
                 {{content}}
             </div>
         </div>


### PR DESCRIPTION
The username of the connected user was displayed under each comment, instead of the username of the comment author.
I replaced tabulations with spaces for the indentation of the file.
